### PR TITLE
Feat/npc brains

### DIFF
--- a/features/npc/Babcia1/babcia1.tscn
+++ b/features/npc/Babcia1/babcia1.tscn
@@ -1,15 +1,17 @@
-[gd_scene load_steps=20 format=3 uid="uid://cnriyx451qbnt"]
+[gd_scene format=3 uid="uid://cnriyx451qbnt"]
 
 [ext_resource type="Script" uid="uid://ck2xha2c0x33n" path="res://features/npc/shared/npc.gd" id="1_qsio3"]
 [ext_resource type="PackedScene" uid="uid://bcni8k42fuo5h" path="res://features/npc/Babcia1/meshes/character_babcia1.glb" id="2_jrrsb"]
 [ext_resource type="AnimationLibrary" uid="uid://bdh170ip7kmc8" path="res://features/npc/shared/Rig.glb" id="3_h8vt2"]
 [ext_resource type="Script" uid="uid://de1lalif7l760" path="res://features/state_machine/state_machine.gd" id="4_yfbun"]
+[ext_resource type="Script" uid="uid://hdtv4grs8ppu" path="res://features/npc/shared/brains/customer_brain.gd" id="4_ykw31"]
 [ext_resource type="Script" uid="uid://dwi10emqduq6r" path="res://features/npc/shared/states/entering_store_state.gd" id="5_xlae7"]
 [ext_resource type="Script" uid="uid://bgodwf3y0m1ey" path="res://features/npc/shared/states/waiting_for_product_state.gd" id="6_npmbd"]
-[ext_resource type="Script" uid="uid://uuvn1btdq2f4" path="res://features/npc/shared/states/getting_product_state.gd" id="7_5coba"]
 [ext_resource type="Script" uid="uid://cxwj4xkryi0sb" path="res://features/npc/shared/states/paying_state.gd" id="8_11j38"]
 [ext_resource type="Script" uid="uid://y8uymo1mwu2j" path="res://features/npc/shared/states/packing_state.gd" id="9_httle"]
 [ext_resource type="Script" uid="uid://j2c8p210clnr" path="res://features/npc/shared/states/exiting_store_state.gd" id="10_duaw0"]
+[ext_resource type="PackedScene" uid="uid://lluh4pryxyhh" path="res://features/npc/shared/inventory/inventory.tscn" id="11_lc4wv"]
+[ext_resource type="Script" uid="uid://bvy8dv8yf6kir" path="res://features/npc/shared/states/standing_in_queue_state.gd" id="11_ykw31"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_wmxm7"]
 radius = 0.3
@@ -52,7 +54,7 @@ nodes/walk_blend/node = SubResource("AnimationNodeBlendSpace1D_xgun3")
 nodes/walk_blend/position = Vector2(-120, 40)
 node_connections = [&"output", 0, &"pick_up", &"pick_up", 0, &"put_down", &"pick_up", 1, &"Animation 2", &"put_down", 0, &"walk_blend", &"put_down", 1, &"Animation"]
 
-[node name="Babcia1" type="CharacterBody3D"]
+[node name="Babcia1" type="CharacterBody3D" unique_id=503636148]
 collision_layer = 8
 axis_lock_angular_x = true
 axis_lock_angular_z = true
@@ -60,13 +62,13 @@ script = ExtResource("1_qsio3")
 metadata/can_interact = false
 metadata/reticle_tooltip = "Basia"
 
-[node name="character_babcia1" parent="." instance=ExtResource("2_jrrsb")]
+[node name="character_babcia1" parent="." unique_id=1224613600 instance=ExtResource("2_jrrsb")]
 
-[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+[node name="CollisionShape3D" type="CollisionShape3D" parent="." unique_id=917860565]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0)
 shape = SubResource("CapsuleShape3D_wmxm7")
 
-[node name="NavigationAgent3D" type="NavigationAgent3D" parent="."]
+[node name="NavigationAgent3D" type="NavigationAgent3D" parent="." unique_id=463920089]
 unique_name_in_owner = true
 path_desired_distance = 0.25
 target_desired_distance = 0.1
@@ -74,14 +76,12 @@ height = 2.0
 radius = 0.3
 debug_enabled = true
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1647719327]
 unique_name_in_owner = true
 root_node = NodePath("../character_babcia1")
-libraries = {
-&"Rig": ExtResource("3_h8vt2")
-}
+libraries/Rig = ExtResource("3_h8vt2")
 
-[node name="AnimationTree" type="AnimationTree" parent="."]
+[node name="AnimationTree" type="AnimationTree" parent="." unique_id=585276377]
 unique_name_in_owner = true
 root_node = NodePath("%AnimationTree/../character_babcia1")
 tree_root = SubResource("AnimationNodeBlendTree_vssg2")
@@ -94,44 +94,51 @@ parameters/put_down/internal_active = false
 parameters/put_down/request = 0
 parameters/walk_blend/blend_position = 0.0
 
-[node name="StateMachine" type="Node" parent="." node_paths=PackedStringArray("initial_state")]
+[node name="Brain" type="Node" parent="." unique_id=1901315223]
+unique_name_in_owner = true
+script = ExtResource("4_ykw31")
+
+[node name="StateMachine" type="Node" parent="." unique_id=668528052 node_paths=PackedStringArray("initial_state")]
 unique_name_in_owner = true
 script = ExtResource("4_yfbun")
 initial_state = NodePath("EnteringStoreState")
 metadata/_custom_type_script = "uid://de1lalif7l760"
 
-[node name="EnteringStoreState" type="Node" parent="StateMachine"]
+[node name="EnteringStoreState" type="Node" parent="StateMachine" unique_id=996059778]
+unique_name_in_owner = true
 script = ExtResource("5_xlae7")
 metadata/_custom_type_script = "uid://dcedhanl8gfas"
 
-[node name="WaitingForProductState" type="Node" parent="StateMachine"]
+[node name="WaitingForProductState" type="Node" parent="StateMachine" unique_id=416906078]
 unique_name_in_owner = true
 script = ExtResource("6_npmbd")
 metadata/_custom_type_script = "uid://dcedhanl8gfas"
 
-[node name="GettingProductState" type="Node" parent="StateMachine"]
-unique_name_in_owner = true
-script = ExtResource("7_5coba")
-metadata/_custom_type_script = "uid://dcedhanl8gfas"
-
-[node name="PayingState" type="Node" parent="StateMachine"]
+[node name="PayingState" type="Node" parent="StateMachine" unique_id=1276452913]
 unique_name_in_owner = true
 script = ExtResource("8_11j38")
 metadata/_custom_type_script = "uid://q0lk35d56y2e"
 
-[node name="PackingState" type="Node" parent="StateMachine"]
+[node name="PackingState" type="Node" parent="StateMachine" unique_id=104068486]
 unique_name_in_owner = true
 script = ExtResource("9_httle")
 metadata/_custom_type_script = "uid://q0lk35d56y2e"
 
-[node name="ExitingStoreState" type="Node" parent="StateMachine"]
+[node name="ExitingStoreState" type="Node" parent="StateMachine" unique_id=317163170]
 unique_name_in_owner = true
 script = ExtResource("10_duaw0")
 metadata/_custom_type_script = "uid://q0lk35d56y2e"
 
-[node name="StateLabel" type="Label3D" parent="."]
+[node name="StandingInQueueState" type="Node" parent="StateMachine" unique_id=1109527637]
+unique_name_in_owner = true
+script = ExtResource("11_ykw31")
+
+[node name="StateLabel" type="Label3D" parent="." unique_id=1767039957]
 unique_name_in_owner = true
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.86561, 0)
 billboard = 2
 font_size = 16
 outline_size = 6
+
+[node name="Inventory" parent="." unique_id=708751401 instance=ExtResource("11_lc4wv")]
+unique_name_in_owner = true

--- a/features/npc/Basia/basia.tscn
+++ b/features/npc/Basia/basia.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" uid="uid://ck2xha2c0x33n" path="res://features/npc/shared/npc.gd" id="1_qlnrj"]
 [ext_resource type="AnimationLibrary" uid="uid://bdh170ip7kmc8" path="res://features/npc/shared/Rig.glb" id="2_0suly"]
 [ext_resource type="Script" uid="uid://de1lalif7l760" path="res://features/state_machine/state_machine.gd" id="4_atgwo"]
+[ext_resource type="Script" uid="uid://dppr5ot05fn28" path="res://features/npc/Basia/basia_brain.gd" id="4_vssg2"]
 [ext_resource type="Script" uid="uid://dwi10emqduq6r" path="res://features/npc/shared/states/entering_store_state.gd" id="5_fyrb5"]
 [ext_resource type="Script" uid="uid://bgodwf3y0m1ey" path="res://features/npc/shared/states/waiting_for_product_state.gd" id="6_a8t5c"]
 [ext_resource type="Script" uid="uid://uuvn1btdq2f4" path="res://features/npc/shared/states/getting_product_state.gd" id="7_mi72n"]
@@ -12,6 +13,7 @@
 [ext_resource type="Script" uid="uid://j2c8p210clnr" path="res://features/npc/shared/states/exiting_store_state.gd" id="10_qlnrj"]
 [ext_resource type="PackedScene" uid="uid://lluh4pryxyhh" path="res://features/npc/shared/inventory/inventory.tscn" id="11_xcwia"]
 [ext_resource type="Script" uid="uid://bvy8dv8yf6kir" path="res://features/npc/shared/states/standing_in_queue_state.gd" id="11_xgun3"]
+[ext_resource type="Script" uid="uid://dbsp7px0jwst6" path="res://features/npc/shared/states/unloading_products_on_counter_state.gd" id="13_26rf4"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_wmxm7"]
 radius = 0.3
@@ -94,6 +96,10 @@ parameters/put_down/internal_active = false
 parameters/put_down/request = 0
 parameters/walk_blend/blend_position = 0.0
 
+[node name="Brain" type="Node" parent="." unique_id=362778679]
+unique_name_in_owner = true
+script = ExtResource("4_vssg2")
+
 [node name="StateMachine" type="Node" parent="." unique_id=178847961 node_paths=PackedStringArray("initial_state")]
 unique_name_in_owner = true
 script = ExtResource("4_atgwo")
@@ -101,6 +107,7 @@ initial_state = NodePath("EnteringStoreState")
 metadata/_custom_type_script = "uid://de1lalif7l760"
 
 [node name="EnteringStoreState" type="Node" parent="StateMachine" unique_id=1954863897]
+unique_name_in_owner = true
 script = ExtResource("5_fyrb5")
 metadata/_custom_type_script = "uid://dcedhanl8gfas"
 
@@ -132,6 +139,10 @@ metadata/_custom_type_script = "uid://q0lk35d56y2e"
 [node name="StandingInQueueState" type="Node" parent="StateMachine" unique_id=987379819]
 unique_name_in_owner = true
 script = ExtResource("11_xgun3")
+
+[node name="UnloadingProductsOnCounterState" type="Node" parent="StateMachine" unique_id=133348511]
+unique_name_in_owner = true
+script = ExtResource("13_26rf4")
 
 [node name="StateLabel" type="Label3D" parent="." unique_id=1254783342]
 unique_name_in_owner = true

--- a/features/npc/Basia/basia_brain.gd
+++ b/features/npc/Basia/basia_brain.gd
@@ -1,0 +1,42 @@
+class_name BasiaBrain
+extends NPCBrain
+
+var wants_help: bool
+
+@onready var entering_store_state: NPCEnteringStoreState = %EnteringStoreState
+@onready var waiting_for_product_state: NPCWaitingForProductState = %WaitingForProductState
+@onready var getting_product_state: NPCGettingProductState = %GettingProductState
+@onready var paying_state: NPCPayingState = %PayingState
+@onready var packing_state: NPCPackingState = %PackingState
+@onready var exiting_store_state: NPCExitingStoreState = %ExitingStoreState
+@onready var standing_in_queue_state: NPCStandingInQueueState = %StandingInQueueState
+@onready var unloading_products_on_counter_state: NPCUnloadingProductsOnCounterState = %UnloadingProductsOnCounterState
+
+func _ready() -> void:
+	state_transitions = [
+		[entering_store_state, getting_product_state],
+		[getting_product_state, standing_in_queue_state],
+		[standing_in_queue_state, unloading_products_on_counter_state, self._has_items_to_unload],
+		[standing_in_queue_state, waiting_for_product_state],
+		[unloading_products_on_counter_state, waiting_for_product_state, self._wants_more_items],
+		[unloading_products_on_counter_state, paying_state],
+		[waiting_for_product_state, paying_state],
+		[paying_state, packing_state],
+		[packing_state, exiting_store_state],
+	]
+
+# TODO: this is a debug override, remove this
+func get_next_state(state: NPCState) -> NPCState:
+	print("Sprawdzam mozliwosc przejscia z ", state.name)
+	var next_state: NPCState = super.get_next_state(state)
+	print("Nastepny stan: ", next_state.name)
+	return next_state
+
+func _wants_help() -> bool:
+	return wants_help
+
+func _has_items_to_unload() -> bool:
+	return not npc.inventory.get_items().is_empty()
+
+func _wants_more_items() -> bool:
+	return not npc.wanted_products.is_empty()

--- a/features/npc/Basia/basia_brain.gd
+++ b/features/npc/Basia/basia_brain.gd
@@ -13,30 +13,14 @@ var wants_help: bool
 @onready var unloading_products_on_counter_state: NPCUnloadingProductsOnCounterState = %UnloadingProductsOnCounterState
 
 func _ready() -> void:
-	state_transitions = [
+	state_transitions.append_array([
 		[entering_store_state, getting_product_state],
 		[getting_product_state, standing_in_queue_state],
-		[standing_in_queue_state, unloading_products_on_counter_state, self._has_items_to_unload],
+		[standing_in_queue_state, unloading_products_on_counter_state, npc.has_items_to_unload],
 		[standing_in_queue_state, waiting_for_product_state],
-		[unloading_products_on_counter_state, waiting_for_product_state, self._wants_more_items],
+		[unloading_products_on_counter_state, waiting_for_product_state, npc.wants_more_items],
 		[unloading_products_on_counter_state, paying_state],
 		[waiting_for_product_state, paying_state],
 		[paying_state, packing_state],
 		[packing_state, exiting_store_state],
-	]
-
-# TODO: this is a debug override, remove this
-func get_next_state(state: NPCState) -> NPCState:
-	print("Sprawdzam mozliwosc przejscia z ", state.name)
-	var next_state: NPCState = super.get_next_state(state)
-	print("Nastepny stan: ", next_state.name)
-	return next_state
-
-func _wants_help() -> bool:
-	return wants_help
-
-func _has_items_to_unload() -> bool:
-	return not npc.inventory.get_items().is_empty()
-
-func _wants_more_items() -> bool:
-	return not npc.wanted_products.is_empty()
+	])

--- a/features/npc/Basia/basia_brain.gd.uid
+++ b/features/npc/Basia/basia_brain.gd.uid
@@ -1,0 +1,1 @@
+uid://dppr5ot05fn28

--- a/features/npc/shared/brains/customer_brain.gd
+++ b/features/npc/shared/brains/customer_brain.gd
@@ -1,0 +1,17 @@
+class_name NPCCustomerBrain extends NPCBrain
+
+@onready var entering_store_state: NPCEnteringStoreState = %EnteringStoreState
+@onready var waiting_for_product_state: NPCWaitingForProductState = %WaitingForProductState
+@onready var paying_state: NPCPayingState = %PayingState
+@onready var packing_state: NPCPackingState = %PackingState
+@onready var exiting_store_state: NPCExitingStoreState = %ExitingStoreState
+@onready var standing_in_queue_state: NPCStandingInQueueState = %StandingInQueueState
+
+func _ready() -> void:
+	state_transitions = [
+		[entering_store_state, standing_in_queue_state],
+		[standing_in_queue_state, waiting_for_product_state],
+		[waiting_for_product_state, paying_state],
+		[paying_state, packing_state],
+		[packing_state, exiting_store_state],
+	]

--- a/features/npc/shared/brains/customer_brain.gd
+++ b/features/npc/shared/brains/customer_brain.gd
@@ -8,10 +8,10 @@ class_name NPCCustomerBrain extends NPCBrain
 @onready var standing_in_queue_state: NPCStandingInQueueState = %StandingInQueueState
 
 func _ready() -> void:
-	state_transitions = [
+	state_transitions.append_array([
 		[entering_store_state, standing_in_queue_state],
 		[standing_in_queue_state, waiting_for_product_state],
 		[waiting_for_product_state, paying_state],
 		[paying_state, packing_state],
 		[packing_state, exiting_store_state],
-	]
+	])

--- a/features/npc/shared/brains/customer_brain.gd.uid
+++ b/features/npc/shared/brains/customer_brain.gd.uid
@@ -1,0 +1,1 @@
+uid://hdtv4grs8ppu

--- a/features/npc/shared/brains/npc_brain.gd
+++ b/features/npc/shared/brains/npc_brain.gd
@@ -1,0 +1,23 @@
+class_name NPCBrain
+extends Node
+
+# This array holds possible state transitions for the NPC. Each element is an array containing:
+# - state_from: the state from which the transition takes place
+# - state_to: the state to which the transition leads
+# - condition_func (optional): an optional function that returns a boolean, determining if the transition is possible
+# the items should be ordered in the way they are checked,
+# the first valid transition, with truthy condition function result or lacking it, will be taken
+var state_transitions: Array[Array] = [] # [[state_from, state_to, condition_func], ...]
+
+
+@onready var npc: NPC = owner
+
+func get_next_state(state: NPCState) -> NPCState:
+	for transition in state_transitions:
+		var state_from: NPCState = transition[0]
+		var state_to: NPCState = transition[1]
+
+		if state_from == state and (transition.size() <= 2 or transition[2].call()):
+			return state_to
+
+	return null

--- a/features/npc/shared/brains/npc_brain.gd
+++ b/features/npc/shared/brains/npc_brain.gd
@@ -1,3 +1,4 @@
+@abstract
 class_name NPCBrain
 extends Node
 
@@ -20,4 +21,5 @@ func get_next_state(state: NPCState) -> NPCState:
 		if state_from == state and (transition.size() <= 2 or transition[2].call()):
 			return state_to
 
+	push_error("No valid state transition found from state %s in NPC %s!" % [state.name, npc.name])
 	return null

--- a/features/npc/shared/brains/npc_brain.gd.uid
+++ b/features/npc/shared/brains/npc_brain.gd.uid
@@ -1,0 +1,1 @@
+uid://cf2l3uvb6kgac

--- a/features/npc/shared/npc.gd
+++ b/features/npc/shared/npc.gd
@@ -65,6 +65,11 @@ func navigate_to_node(node: Node3D) -> void:
 	_target_node = node
 	nav_agent.target_position = _target_node.global_position
 
+func has_items_to_unload() -> bool:
+	return not inventory.get_items().is_empty()
+
+func wants_more_items() -> bool:
+	return not wanted_products.is_empty()
 
 func _on_navigation_finished() -> void:
 

--- a/features/npc/shared/npc.gd
+++ b/features/npc/shared/npc.gd
@@ -18,7 +18,7 @@ var _navigation_interrupted: bool = false
 @onready var state_machine: StateMachine = %StateMachine
 @onready var info_label: Label3D = %StateLabel
 @onready var inventory: Inventory = %Inventory
-
+@onready var brain: NPCBrain = %Brain
 
 func _ready() -> void:
 

--- a/features/npc/shared/states/entering_store_state.gd
+++ b/features/npc/shared/states/entering_store_state.gd
@@ -1,44 +1,27 @@
 class_name NPCEnteringStoreState extends NPCState
 
 
-@onready var waiting_for_product_state: NPCWaitingForProductState = %WaitingForProductState
-@onready var standing_in_queue_state: NPCStandingInQueueState = %StandingInQueueState
-@onready var getting_product_state: NPCGettingProductState = %GettingProductState
-
-
-
 func enter() -> void:
-
-	print("Basiula wchodzi do sklepu...")
+	print("%s wchodzi do sklepu..." % npc.name)
 	await get_tree().create_timer(5.0).timeout
-	print("Basiula skonczyla wchodzic do sklepu.")
-	var wants_help: bool = [true, false].pick_random()
-	print("Tu bedzie losowanie produktow, jakie chce Basiula. Na razie chce browara.")
-	npc.wanted_products = Level.instance.available_items.get_all_item_names()
-	print("Basiula chce: ", npc.wanted_products)
-	if wants_help:
-		print("Basiula jest leniwa i chce miec produkt przyniesiony na lade.")
-		transition.emit(standing_in_queue_state)
-	else:
-		print("Basiula sama sobie znajdzie produkt.")
-		transition.emit(getting_product_state)
+	print("%s skonczyla wchodzic do sklepu." % npc.name)
+	print("Tu bedzie losowanie produktow, jakie chce %s." % npc.name)
+	npc.wanted_products = Level.instance.available_items.get_all_item_names().slice(0, 2)
+	print("%s chce: %s" % [npc.name, ", ".join(npc.wanted_products)])
+	transition.emit(npc.brain.get_next_state(self))
 
 
 func input_event(_event: InputEvent) -> void:
-
 	pass
 
 
 func update(_delta: float) -> void:
-
 	pass
 
 
 func physics_update(_delta: float) -> void:
-
 	pass
 
 
 func exit() -> void:
-
 	pass

--- a/features/npc/shared/states/exiting_store_state.gd
+++ b/features/npc/shared/states/exiting_store_state.gd
@@ -2,28 +2,22 @@ class_name NPCExitingStoreState extends NPCState
 
 
 func enter() -> void:
-
-	print("Basia wychodzi ze sklepu")
+	print("%s wychodzi ze sklepu" % npc.name)
 	npc.navigate_to_node(Level.instance.main_door)
 	await npc.nav_agent.navigation_finished
 	npc.call_deferred(&"queue_free") # NOTE: Crash when not deferred
 
-
 func input_event(_event: InputEvent) -> void:
-
 	pass
 
 
 func update(_delta: float) -> void:
-
 	pass
 
 
 func physics_update(_delta: float) -> void:
-
 	pass
 
 
 func exit() -> void:
-
 	pass

--- a/features/npc/shared/states/getting_product_state.gd
+++ b/features/npc/shared/states/getting_product_state.gd
@@ -6,7 +6,6 @@ var current_product: StringName
 
 @onready var animation_player: AnimationPlayer = %AnimationPlayer
 @onready var animation_tree: AnimationTree = %AnimationTree
-@onready var standing_in_queue_state: NPCStandingInQueueState = %StandingInQueueState
 
 
 func enter() -> void:
@@ -38,7 +37,7 @@ func _go_to_next_product() -> void:
 		current_product = wanted_products.pop_front()
 		_get_product(current_product)
 	else:
-		transition.emit(standing_in_queue_state)
+		transition.emit(npc.brain.get_next_state(self))
 
 func _get_product(product_name: StringName) -> void:
 	var item: Item = Level.instance.available_items.get_item(product_name)

--- a/features/npc/shared/states/packing_state.gd
+++ b/features/npc/shared/states/packing_state.gd
@@ -2,36 +2,29 @@ class_name NPCPackingState extends NPCState
 
 
 @onready var animation_tree: AnimationTree = %AnimationTree
-@onready var exiting_store_state: NPCExitingStoreState = %ExitingStoreState
 
 
 func enter() -> void:
-
 	animation_tree.animation_finished.connect(_on_animation_finished)
 	animation_tree.set(&"parameters/pick_up/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)
 
 
 func input_event(_event: InputEvent) -> void:
-
 	pass
 
 
 func update(_delta: float) -> void:
-
 	pass
 
 
 func physics_update(_delta: float) -> void:
-
 	pass
 
 
 func _on_animation_finished(anim_name: StringName) -> void:
-
 	if anim_name == &"Rig/PickUp_Base":
-
 		Counter.instance.clear()
-		transition.emit(exiting_store_state)
+		transition.emit(npc.brain.get_next_state(self))
 
 
 func exit() -> void:
@@ -40,4 +33,4 @@ func exit() -> void:
 		Game.instance.npc_queue.dequeue()
 		Game.instance.move_npc_queue()
 	else:
-		push_error("NPC opuszczający kolejkę nie jest na jej początku!")
+		push_error("NPC %s opuszczający kolejkę nie jest na jej początku!" % npc.name)

--- a/features/npc/shared/states/paying_state.gd
+++ b/features/npc/shared/states/paying_state.gd
@@ -2,28 +2,23 @@ class_name NPCPayingState extends NPCState
 
 
 @onready var animation_tree: AnimationTree = %AnimationTree
-@onready var packing_state: NPCPackingState = %PackingState
 
 
 func enter() -> void:
-
 	animation_tree.animation_finished.connect(_on_animation_finished)
 	CashRegister.instance.transaction_finished.connect(_on_transaction_finished)
 	animation_tree.set(&"parameters/put_down/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)
 
 
 func input_event(_event: InputEvent) -> void:
-
 	pass
 
 
 func update(_delta: float) -> void:
-
 	pass
 
 
 func physics_update(_delta: float) -> void:
-
 	pass
 
 
@@ -32,11 +27,9 @@ func _on_animation_finished(anim_name: StringName) -> void:
 		CashRegister.instance.generate_random_order()
 
 func _on_transaction_finished() -> void:
-
-	transition.emit(packing_state)
+	transition.emit(npc.brain.get_next_state(self))
 
 
 func exit() -> void:
-
 	animation_tree.animation_finished.disconnect(_on_animation_finished)
 	CashRegister.instance.transaction_finished.disconnect(_on_transaction_finished)

--- a/features/npc/shared/states/standing_in_queue_state.gd
+++ b/features/npc/shared/states/standing_in_queue_state.gd
@@ -1,17 +1,12 @@
 class_name NPCStandingInQueueState
 extends NPCState
 
-const QUEUE_SPACING: float = 1.0
+const QUEUE_SPACING: float = 0.75
+const FIRST_IN_QUEUE_OFFSET: Vector3 = Vector3(0, 0, 0.75)
 
 func enter() -> void:
-	if Game.instance.npc_queue.is_empty():
-		print("Kolejka jest pusta.")
-		_move_to_counter()
-	else:
-		print("%s staje w kolejce." % npc.name)
-		_move_to_queue_end()
-		
 	Game.instance.npc_queue.enqueue(npc)
+	_move_to_queue_position(Game.instance.npc_queue.list().size() - 1)
 	Game.instance.npc_in_queue_moved.connect(_move_in_queue)
 
 func input_event(_event: InputEvent) -> void:
@@ -23,32 +18,29 @@ func update(_delta: float) -> void:
 func physics_update(_delta: float) -> void:
 	pass
 
-func _move_to_counter() -> void:
-	print("%s podchodzi do lady." % npc.name)
-	npc.navigate_to_node(Counter.instance)
-	await npc.nav_agent.navigation_finished
-	transition.emit(npc.brain.get_next_state(self))
-
-func _move_to_queue_end() -> void:
-	print("%s przesuwa się na koniec kolejki." % npc.name)
-	_move_behind_npc(Game.instance.npc_queue.peek_tail())
-
-func _move_in_queue(queued_npc: Game.QueuedNPC) -> void:
+func _move_in_queue(queued_npc: Game.QueuedNPC, position_in_queue: int) -> void:
 	if queued_npc.npc != npc: return
 
-	print("%s przesuwa się w kolejce." % npc.name)
-	if Game.instance.npc_queue.peek() == npc:
-		_move_to_counter()
-	else:
-		_move_behind_npc(queued_npc.previous.npc)
+	_move_to_queue_position(position_in_queue)
 
-func _move_behind_npc(target_npc: NPC) -> void:
-	var queue_position: Node3D = _create_temporary_position_node()
-	queue_position.global_position = target_npc.global_position + Vector3(0, 0, QUEUE_SPACING)
-	npc.navigate_to_node(queue_position)
+func _move_to_queue_position(index: int) -> void:
+	var queue_position: Node3D
+	if index == 0:
+		npc.navigate_to_node(Counter.instance)
+		await npc.nav_agent.navigation_finished
+	else:
+		var base_position: Vector3 = Counter.instance.global_position
+
+		queue_position = _create_temporary_position_node()
+		queue_position.global_position = base_position + Vector3(0, 0, QUEUE_SPACING * index) + FIRST_IN_QUEUE_OFFSET
+		npc.navigate_to_node(queue_position)
+
 	await npc.nav_agent.navigation_finished
-	queue_position.queue_free()
 	_look_at_counter()
+	queue_position.queue_free()
+
+	if index == 0:
+		transition.emit(npc.brain.get_next_state(self))
 
 func _create_temporary_position_node() -> Node3D:
 	var temp_node: Node3D = Node3D.new()

--- a/features/npc/shared/states/standing_in_queue_state.gd
+++ b/features/npc/shared/states/standing_in_queue_state.gd
@@ -3,14 +3,12 @@ extends NPCState
 
 const QUEUE_SPACING: float = 1.0
 
-@onready var waiting_for_product_state: NPCWaitingForProductState = %WaitingForProductState
-
 func enter() -> void:
 	if Game.instance.npc_queue.is_empty():
 		print("Kolejka jest pusta.")
 		_move_to_counter()
 	else:
-		print("Basia staje w kolejce.")
+		print("%s staje w kolejce." % npc.name)
 		_move_to_queue_end()
 		
 	Game.instance.npc_queue.enqueue(npc)
@@ -26,19 +24,19 @@ func physics_update(_delta: float) -> void:
 	pass
 
 func _move_to_counter() -> void:
-	print("Basia podchodzi do lady.")
+	print("%s podchodzi do lady." % npc.name)
 	npc.navigate_to_node(Counter.instance)
 	await npc.nav_agent.navigation_finished
-	transition.emit(waiting_for_product_state)
+	transition.emit(npc.brain.get_next_state(self))
 
 func _move_to_queue_end() -> void:
-	print("Basia przesuwa się na koniec kolejki.")
+	print("%s przesuwa się na koniec kolejki." % npc.name)
 	_move_behind_npc(Game.instance.npc_queue.peek_tail())
 
 func _move_in_queue(queued_npc: Game.QueuedNPC) -> void:
 	if queued_npc.npc != npc: return
 
-	print("Basia przesuwa się w kolejce.")
+	print("%s przesuwa się w kolejce." % npc.name)
 	if Game.instance.npc_queue.peek() == npc:
 		_move_to_counter()
 	else:

--- a/features/npc/shared/states/unloading_products_on_counter_state.gd
+++ b/features/npc/shared/states/unloading_products_on_counter_state.gd
@@ -1,0 +1,48 @@
+class_name NPCUnloadingProductsOnCounterState extends NPCState
+
+
+@onready var animation_tree: AnimationTree = %AnimationTree
+
+
+func enter() -> void:
+	animation_tree.animation_finished.connect(_on_animation_finished)
+	Counter.instance.item_placed.connect(_on_counter_item_placed)
+
+	if not npc.inventory.get_items().is_empty():
+		print("%s ma loot w eq. Odkłada produkty na ladę." % npc.name)
+		animation_tree.set(&"parameters/put_down/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)
+	else:
+		transition.emit(npc.brain.get_next_state(self))
+
+func input_event(_event: InputEvent) -> void:
+	pass
+
+
+func update(_delta: float) -> void:
+	pass
+
+
+func physics_update(_delta: float) -> void:
+	pass
+
+func _on_animation_finished(anim_name: StringName) -> void:
+	if anim_name == &"Rig/PutDown_Base":
+		_unload_inventory_on_counter()
+
+func _on_counter_item_placed(item_data: ItemData) -> void:
+	if npc.wanted_products.has(item_data.name):
+		npc.wanted_products.erase(item_data.name)
+
+	if npc.wanted_products.is_empty():
+		transition.emit(npc.brain.get_next_state(self))
+
+func _unload_inventory_on_counter() -> void:
+	for item: Item in npc.inventory.get_items():
+		var interact_event: InputEventAction = InputEventAction.new()
+		interact_event.action = &"interact"
+		interact_event.pressed = true
+		Counter.instance.interact(interact_event, item)
+
+func exit() -> void:
+	animation_tree.animation_finished.disconnect(_on_animation_finished)
+	Counter.instance.item_placed.disconnect(_on_counter_item_placed)

--- a/features/npc/shared/states/unloading_products_on_counter_state.gd.uid
+++ b/features/npc/shared/states/unloading_products_on_counter_state.gd.uid
@@ -1,0 +1,1 @@
+uid://dbsp7px0jwst6

--- a/features/npc/shared/states/waiting_for_product_state.gd
+++ b/features/npc/shared/states/waiting_for_product_state.gd
@@ -2,21 +2,12 @@ class_name NPCWaitingForProductState extends NPCState
 
 
 @onready var animation_tree: AnimationTree = %AnimationTree
-@onready var paying_state: NPCPayingState = %PayingState
 
 
 func enter() -> void:
-	animation_tree.animation_finished.connect(_on_animation_finished)
 	Counter.instance.item_placed.connect(_on_counter_item_placed)
 	npc.set_meta(&"can_interact", true)
-	print("Basiula podeszla do lady. Tu bedzie okienko dialogowe. Na razie czeka na bobra w butelce.")
-
-	if not npc.inventory.get_items().is_empty():
-		print("Basiula ma loot w eq. Odkłada produkty na ladę.")
-		animation_tree.set(&"parameters/put_down/request", AnimationNodeOneShot.ONE_SHOT_REQUEST_FIRE)
-
-	if npc.wanted_products.is_empty():
-		transition.emit(paying_state)
+	print("%s podchodzi do lady. Tu bedzie okienko dialogowe. Na razie czeka na : %s" % [npc.name, ", ".join(npc.wanted_products)])
 
 func input_event(_event: InputEvent) -> void:
 	pass
@@ -29,25 +20,13 @@ func update(_delta: float) -> void:
 func physics_update(_delta: float) -> void:
 	pass
 
-func _on_animation_finished(anim_name: StringName) -> void:
-	if anim_name == &"Rig/PutDown_Base":
-		_unload_inventory_on_counter()
-
 func _on_counter_item_placed(item_data: ItemData) -> void:
 	if npc.wanted_products.has(item_data.name):
 		npc.wanted_products.erase(item_data.name)
 
 	if npc.wanted_products.is_empty():
-		transition.emit(paying_state)
-
-func _unload_inventory_on_counter() -> void:
-	for item: Item in npc.inventory.get_items():
-		var interact_event: InputEventAction = InputEventAction.new()
-		interact_event.action = &"interact"
-		interact_event.pressed = true
-		Counter.instance.interact(interact_event, item)
+		transition.emit(npc.brain.get_next_state(self))
 
 func exit() -> void:
-	animation_tree.animation_finished.disconnect(_on_animation_finished)
 	Counter.instance.item_placed.disconnect(_on_counter_item_placed)
 	npc.set_meta(&"can_interact", false)

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -22,6 +22,7 @@ func _ready() -> void:
 	pause_menu.unpaused.connect(player.hud.on_game_unpaused)
 
 	DebugMenu.add_button(spawn_basia)
+	DebugMenu.add_button(spawn_babcia)
 	DebugMenu.add_button(change_window_mode)
 
 	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
@@ -34,14 +35,11 @@ func _ready() -> void:
 func _process(_delta: float) -> void:
 	DebugPanel.add_property(Engine.get_frames_per_second(), "FPS", 1000)
 
-
 func spawn_basia() -> void:
-	var basia_scene: PackedScene = load("uid://civlo6dh6d0kf")
-	var basia: NPC = basia_scene.instantiate()
-	npcs.add_child(basia)
-	basia.position = Vector3(-1.48, 0.125, 3.42)
-	basia.rotation_degrees = Vector3(0.0, -180.0, 0.0)
+	_spawn_npc("uid://civlo6dh6d0kf", Vector3(-1.48, 0.125, 3.42), Vector3(0.0, -180.0, 0.0))
 
+func spawn_babcia() -> void:
+	_spawn_npc("uid://cnriyx451qbnt", Vector3(-1.48, 0.125, 3.42), Vector3(0.0, -180.0, 0.0))
 
 func change_window_mode() -> void:
 	var window: Window = get_window()
@@ -52,6 +50,13 @@ func move_npc_queue() -> void:
 	for queued_npc in npc_queue.list():
 		npc_in_queue_moved.emit(queued_npc)
 		await queued_npc.npc.nav_agent.navigation_finished
+
+func _spawn_npc(resource_id: String, position: Vector3, rotation_degrees: Vector3) -> void:
+	var npc_scene: PackedScene = load(resource_id)
+	var npc: NPC = npc_scene.instantiate()
+	npcs.add_child(npc)
+	npc.position = position
+	npc.rotation_degrees = rotation_degrees
 
 class NPCQueue:
 	var head: QueuedNPC

--- a/scenes/game/game.gd
+++ b/scenes/game/game.gd
@@ -1,6 +1,6 @@
 class_name Game extends Node
 
-signal npc_in_queue_moved(queued_npc: QueuedNPC)
+signal npc_in_queue_moved(queued_npc: QueuedNPC, position_in_queue: int)
 
 static var instance: Game
 
@@ -47,9 +47,11 @@ func change_window_mode() -> void:
 	else: window.mode = Window.MODE_WINDOWED
 
 func move_npc_queue() -> void:
+	var index: int = 0
 	for queued_npc in npc_queue.list():
-		npc_in_queue_moved.emit(queued_npc)
+		npc_in_queue_moved.emit(queued_npc, index)
 		await queued_npc.npc.nav_agent.navigation_finished
+		index += 1
 
 func _spawn_npc(resource_id: String, position: Vector3, rotation_degrees: Vector3) -> void:
 	var npc_scene: PackedScene = load(resource_id)


### PR DESCRIPTION
Extracting state transition mechanism from states.

`NPCBrain` node is created, that can store available and conditional state transitions, allowing for more advanced and granular state control.

Different implementations of the `NPCBrains` can be created for each NPC, allowing for custom behavior based on the current state system.