### PR TITLE
Feat/item costs and product ordering

### DIFF
--- a/features/cash_register/cash_register.gd
+++ b/features/cash_register/cash_register.gd
@@ -1,16 +1,19 @@
 class_name CashRegister extends StaticBody3D
 
-
 signal transaction_finished
-
 
 static var instance: CashRegister
 
+const PAYMENT_ROUNDING_OPTIONS: Array[float] = [10.0, 20.0, 50.0]
+const TOTAL_ROUNDING_OPTIONS: Array[float] = [1.0, 0.5]
+const RANDOM_TOTAL_MIN: float = 50.0
+const RANDOM_TOTAL_MAX: float = 200.0
+const MAX_CHANGE: float = 1000.0
 
+var is_order_in_progress: bool = false
 var total: float = 0.0
 var paid: float = 0.0
 var change: float = 0.0
-
 
 @onready var total_label: Label = %TotalLabel
 @onready var paid_label: Label = %PaidLabel
@@ -22,46 +25,93 @@ func _init() -> void:
 	instance = self
 
 func _ready() -> void:
-
+	Counter.instance.product_placed.connect(_on_item_add_to_order)
+	
 	for node: Money in get_tree().get_nodes_in_group(&"Cash"):
-
 		node.interaction.connect(_on_cash_interaction)
 
+func start_new_order() -> void:
+	if not _can_start_new_order():
+		return
+
+	_begin_order()
+
+func generate_order_and_payment() -> void:
+	paid = _calculate_payment_for_total(total)
+	_show_order()
 
 func generate_random_order() -> void:
-	var total_rounding: float = [1.0, 0.5].pick_random()
-	total = randf_range(50.0, 200.0)
-	total = snappedf(total, total_rounding)
+	total = _generate_random_total()
+	paid = _calculate_payment_for_total(total)
+	_show_order()
 
-	var paid_rounding: float = [10.0, 20.0, 50.0].pick_random()
-	paid = snappedf(total, paid_rounding)
-	paid += paid_rounding if paid <= total else 0.0
+func _can_start_new_order() -> bool:
+	if is_order_in_progress:
+		push_error("Cannot start a new order while another order is in progress.")
+		return false
 
-	total_label.text = str(total)
-	paid_label.text = str(paid)
+	return true
 
+func _begin_order() -> void:
+	is_order_in_progress = true
+	reset_order()
+	labels_container.hide()
+
+func reset_order() -> void:
+	total = 0.0
+	paid = 0.0
+	change = 0.0
+
+func _display_current_order() -> void:
+	_update_order_display()
 	labels_container.show()
 
-	if not drawer.open:
+func _generate_random_total() -> float:
+	var total_rounding: float = TOTAL_ROUNDING_OPTIONS.pick_random()
+	var random_total: float = randf_range(RANDOM_TOTAL_MIN, RANDOM_TOTAL_MAX)
+	return snappedf(random_total, total_rounding)
 
+func _calculate_payment_for_total(order_total: float) -> float:
+	var paid_rounding: float = PAYMENT_ROUNDING_OPTIONS.pick_random()
+	var rounded_payment: float = snappedf(order_total, paid_rounding)
+	if rounded_payment <= order_total:
+		rounded_payment += paid_rounding
+
+	return rounded_payment
+
+func _show_order() -> void:
+	_display_current_order()
+	if not drawer.open:
 		drawer.open_drawer()
 
+func _update_order_display() -> void:
+	total_label.text = str(total)
+	paid_label.text = str(paid)
+	change_label.text = str(change)
 
 func _change_value_changed(value: float) -> void:
-
-	change = clampf(change + value, 0.0, 1000.0)
-	change_label.text = str(change)
-	if is_equal_approx(paid, total + change):
-
-		drawer.close_drawer()
-		labels_container.hide()
-		total = 0.0
-		paid = 0.0
-		change = 0.0
-		transaction_finished.emit()
+	change = clampf(change + value, 0.0, MAX_CHANGE)
 	change_label.text = str(change)
 
+	if _is_transaction_complete():
+		_finish_transaction()
+
+func _is_transaction_complete() -> bool:
+	return is_equal_approx(paid, total + change)
+
+func _finish_transaction() -> void:
+	drawer.close_drawer()
+	labels_container.hide()
+	reset_order()
+	is_order_in_progress = false
+	transaction_finished.emit()
 
 func _on_cash_interaction(value: float) -> void:
-
 	_change_value_changed(value)
+
+func _on_item_add_to_order(item_data: ProductData) -> void:
+	if not is_order_in_progress:
+		return
+
+	total += item_data.price
+	_update_order_display()

--- a/features/counter/counter.gd
+++ b/features/counter/counter.gd
@@ -1,7 +1,7 @@
 class_name Counter extends StaticBody3D
 
 
-signal item_placed(item_data: ItemData)
+signal product_placed(product_data: ProductData)
 
 
 const TWEEN_DURATION: float = 0.25
@@ -9,11 +9,33 @@ const TWEEN_DURATION: float = 0.25
 
 static var instance: Counter
 
-
 var _cigs_counter: int = 0
 var _beer_counter: int = 0
 var _misc_counter: int = 0
+var _npc_at_counter: NPC = null
+var _player_has_item_in_hand: bool = false
+var _is_customer_waiting_for_product: bool = false
 
+var npc_at_counter: NPC = null:
+	set(value):
+		_npc_at_counter = value
+		_is_customer_waiting_for_product = (value != null)
+	get:
+		return _npc_at_counter
+
+var player_has_item_in_hand: bool:
+	get:
+		return _player_has_item_in_hand
+	set(value):
+		_player_has_item_in_hand = value
+		set_meta(&"can_interact", value and _is_customer_waiting_for_product)
+
+var is_customer_waiting_for_product: bool:
+	get:
+		return _is_customer_waiting_for_product
+	set(value):
+		_is_customer_waiting_for_product = value
+		set_meta(&"can_interact", value and _player_has_item_in_hand)
 
 @onready var _cig_targets: Array[Node] = get_tree().get_nodes_in_group(&"cig_targets")
 @onready var _beer_targets: Array[Node] = get_tree().get_nodes_in_group(&"beer_targets")
@@ -25,13 +47,42 @@ func _init() -> void:
 
 
 func interact(event: InputEvent, item_in_hand: Item) -> void:
+	if not event.is_action_pressed(&"interact"):
+		return
 
-	if not event.is_action_pressed(&"interact"): return
+	if not _is_placeable_product_item(item_in_hand):
+		return
 
-	if is_instance_valid(item_in_hand):
+	if not _can_place_player_item(item_in_hand.data):
+		return
 
-		_place_item_on_counter(item_in_hand)
-		set_meta(&"can_interact", false)
+	_place_item_on_counter(item_in_hand)
+	# set_meta(&"can_interact", false)
+
+
+func place_item_from_npc(item_in_hand: Item) -> void:
+	if not _is_placeable_product_item(item_in_hand):
+		return
+
+	_place_item_on_counter(item_in_hand)
+
+
+func _is_placeable_product_item(item_in_hand: Item) -> bool:
+	if not is_instance_valid(item_in_hand):
+		return false
+
+	return item_in_hand.data is ProductData
+
+
+func _can_place_player_item(product_data: ProductData) -> bool:
+	if not _is_player_interaction_allowed():
+		return false
+
+	return npc_at_counter.wanted_products.has(product_data.name)
+
+
+func _is_player_interaction_allowed() -> bool:
+	return is_instance_valid(npc_at_counter) and npc_at_counter.wants_more_items()
 
 
 func clear() -> void:
@@ -44,13 +95,11 @@ func clear() -> void:
 
 
 func on_item_entered_rig(_item: Item) -> void:
-
-	set_meta(&"can_interact", true)
+	player_has_item_in_hand = true
 
 
 func on_item_exited_rig() -> void:
-
-	set_meta(&"can_interact", false)
+	player_has_item_in_hand = false
 
 
 func _move_item_to_target(item: Item, target: Marker3D) -> void:
@@ -70,27 +119,30 @@ func _move_item_to_target(item: Item, target: Marker3D) -> void:
 
 func _place_item_on_counter(item: Item) -> void:
 
-	item.remove_meta(&"can_interact")
-	item.remove_meta(&"reticle_tooltip")
-
+	var product_data: ProductData = item.data
 	var target: Marker3D
-	if item.data.type == ItemData.Type.SZLUGI:
+	if product_data.type == ItemData.Type.SZLUGI:
 
 		if _cigs_counter >= _cig_targets.size(): return
 		target = _cig_targets[_cigs_counter]
 		_cigs_counter += 1
 
-	elif item.data.type == ItemData.Type.PIWO or item.data.type == ItemData.Type.WINO:
+	elif product_data.type == ItemData.Type.PIWO or product_data.type == ItemData.Type.WINO:
 		if _beer_counter >= _beer_targets.size(): return
 		target = _beer_targets[_beer_counter]
 		_beer_counter += 1
 
-	elif item.data.type == ItemData.Type.MISC:
+	elif product_data.type == ItemData.Type.MISC:
 
 		if _misc_counter >= _misc_targets.size(): return
 		target = _misc_targets[_misc_counter]
 		_misc_counter += 1
 
+	else: return
+
+	item.remove_meta(&"can_interact")
+	item.remove_meta(&"reticle_tooltip")
+
 	await _move_item_to_target(item, target)
-	item_placed.emit(item.data)
+	product_placed.emit(product_data)
 	item.reparent(_items)

--- a/features/items/item_data/beer/data_boskie_bottle.tres
+++ b/features/items/item_data/beer/data_boskie_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://bd64bdlgx3b24"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bd64bdlgx3b24"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_i7333"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_i7333"]
 
 [resource]
 script = ExtResource("1_i7333")
+price = 2.0
 name = &"boskie_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_boskie_can.tres
+++ b/features/items/item_data/beer/data_boskie_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://lee4tlfiqb66"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://lee4tlfiqb66"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_jncv3"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_jncv3"]
 
 [resource]
 script = ExtResource("1_jncv3")
+price = 1.7
 name = &"boskie_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_bubr_bottle.tres
+++ b/features/items/item_data/beer/data_bubr_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://da7xupii6x351"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://da7xupii6x351"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_4kcy1"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_4kcy1"]
 
 [resource]
 script = ExtResource("1_4kcy1")
+price = 1.8
 name = &"bubr_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_bubr_can.tres
+++ b/features/items/item_data/beer/data_bubr_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://dcenargdwox6w"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://dcenargdwox6w"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_ylq35"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_ylq35"]
 
 [resource]
 script = ExtResource("1_ylq35")
+price = 1.5
 name = &"bubr_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_jp_bottle.tres
+++ b/features/items/item_data/beer/data_jp_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://vsunu5jhtik"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://vsunu5jhtik"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_oc6p4"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_oc6p4"]
 
 [resource]
 script = ExtResource("1_oc6p4")
+price = 1.9
 name = &"jp_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_jp_can.tres
+++ b/features/items/item_data/beer/data_jp_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://eusb2p3gq37u"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://eusb2p3gq37u"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_btby1"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_btby1"]
 
 [resource]
 script = ExtResource("1_btby1")
+price = 1.6
 name = &"jp_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_mech_bottle.tres
+++ b/features/items/item_data/beer/data_mech_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://bu7l60yv00wc"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bu7l60yv00wc"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_52tqu"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_52tqu"]
 
 [resource]
 script = ExtResource("1_52tqu")
+price = 2.6
 name = &"mech_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_mech_can.tres
+++ b/features/items/item_data/beer/data_mech_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://dpwim8fys7nwl"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://dpwim8fys7nwl"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_y4ltx"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_y4ltx"]
 
 [resource]
 script = ExtResource("1_y4ltx")
+price = 2.3
 name = &"mech_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_ovecky_bottle.tres
+++ b/features/items/item_data/beer/data_ovecky_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://ddj131p6imt8a"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://ddj131p6imt8a"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_hnhup"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_hnhup"]
 
 [resource]
 script = ExtResource("1_hnhup")
+price = 2.3
 name = &"ovecky_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_ovecky_can.tres
+++ b/features/items/item_data/beer/data_ovecky_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://bi5pxvyhoybwr"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bi5pxvyhoybwr"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_ebyk2"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_ebyk2"]
 
 [resource]
 script = ExtResource("1_ebyk2")
+price = 2.0
 name = &"ovecky_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_tarka_bottle.tres
+++ b/features/items/item_data/beer/data_tarka_bottle.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://nwm8c1ppi3ad"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://nwm8c1ppi3ad"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_bsqh7"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_bsqh7"]
 
 [resource]
 script = ExtResource("1_bsqh7")
+price = 2.1
 name = &"tarka_bottle"
 type = 1
 preview_zoom = -0.28
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/beer/data_tarka_can.tres
+++ b/features/items/item_data/beer/data_tarka_can.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://rl8bg7qfdcej"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://rl8bg7qfdcej"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_83pja"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_83pja"]
 
 [resource]
 script = ExtResource("1_83pja")
+price = 1.8
 name = &"tarka_can"
 type = 1
 preview_zoom = -0.25
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_alpaca.tres
+++ b/features/items/item_data/cigarettes/data_alpaca.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://ywdht0o3owu3"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://ywdht0o3owu3"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_0ryav"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_0ryav"]
 
 [resource]
 script = ExtResource("1_0ryav")
+price = 6.5
 name = &"alpaca"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_kiceroy.tres
+++ b/features/items/item_data/cigarettes/data_kiceroy.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://dpk0onncordnk"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://dpk0onncordnk"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_sefd7"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_sefd7"]
 
 [resource]
 script = ExtResource("1_sefd7")
+price = 5.1
 name = &"kiceroy"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_mamboro.tres
+++ b/features/items/item_data/cigarettes/data_mamboro.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://d3yqe5yr5yh78"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://d3yqe5yr5yh78"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_dc2ji"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_dc2ji"]
 
 [resource]
 script = ExtResource("1_dc2ji")
+price = 8.0
 name = &"mamboro"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_masterfield.tres
+++ b/features/items/item_data/cigarettes/data_masterfield.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://d2mkjnh0qgfmp"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://d2mkjnh0qgfmp"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_0gjpv"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_0gjpv"]
 
 [resource]
 script = ExtResource("1_0gjpv")
+price = 4.8
 name = &"masterfield"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_platinum.tres
+++ b/features/items/item_data/cigarettes/data_platinum.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://cnkor7p7gm7pd"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://cnkor7p7gm7pd"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_nj6b7"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_nj6b7"]
 
 [resource]
 script = ExtResource("1_nj6b7")
+price = 5.0
 name = &"platinum"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/cigarettes/data_silne.tres
+++ b/features/items/item_data/cigarettes/data_silne.tres
@@ -1,11 +1,9 @@
-[gd_resource type="Resource" script_class="ItemData" load_steps=2 format=3 uid="uid://ck73t0cglgxr6"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://ck73t0cglgxr6"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_huwav"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_huwav"]
 
 [resource]
 script = ExtResource("1_huwav")
+price = 3.5
 name = &"silne"
-type = 0
-preview_zoom = -0.15
-rig_position = Vector3(0.1, -0.075, -0.2)
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/product_data.gd
+++ b/features/items/item_data/product_data.gd
@@ -1,0 +1,3 @@
+class_name ProductData extends ItemData
+
+@export var price: float = 0.0

--- a/features/items/item_data/product_data.gd.uid
+++ b/features/items/item_data/product_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bjdyvmcp7aon

--- a/features/items/item_data/wines/data_arena.tres
+++ b/features/items/item_data/wines/data_arena.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://hx04otlco6x8"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://hx04otlco6x8"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_8agq5"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_8agq5"]
 
 [resource]
 script = ExtResource("1_8agq5")
+price = 3.5
 name = &"arena"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_breslau.tres
+++ b/features/items/item_data/wines/data_breslau.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://bxoky8lw2yola"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bxoky8lw2yola"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_80nko"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_80nko"]
 
 [resource]
 script = ExtResource("1_80nko")
+price = 3.5
 name = &"breslau"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_dobreto.tres
+++ b/features/items/item_data/wines/data_dobreto.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://dm48vl6n3re8n"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://dm48vl6n3re8n"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_77y4q"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_77y4q"]
 
 [resource]
 script = ExtResource("1_77y4q")
+price = 3.5
 name = &"dobreto"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_jabluszko_pomorskie.tres
+++ b/features/items/item_data/wines/data_jabluszko_pomorskie.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://bvjynkjt64j78"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bvjynkjt64j78"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_bbh1m"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_bbh1m"]
 
 [resource]
 script = ExtResource("1_bbh1m")
+price = 3.5
 name = &"jabluszko_pomorskie"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_krolewskie.tres
+++ b/features/items/item_data/wines/data_krolewskie.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://bivetmp0xkw1r"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bivetmp0xkw1r"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_v2o1i"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_v2o1i"]
 
 [resource]
 script = ExtResource("1_v2o1i")
+price = 3.5
 name = &"krolewskie"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_kwiat.tres
+++ b/features/items/item_data/wines/data_kwiat.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://bn120kxh7rpyj"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bn120kxh7rpyj"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_qal6x"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_qal6x"]
 
 [resource]
 script = ExtResource("1_qal6x")
+price = 3.5
 name = &"kwiat"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_pippolo.tres
+++ b/features/items/item_data/wines/data_pippolo.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://dnjm7yivuuf5m"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://dnjm7yivuuf5m"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_qeu05"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_qeu05"]
 
 [resource]
 script = ExtResource("1_qeu05")
+price = 3.5
 name = &"pippolo"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_ruski_szampan.tres
+++ b/features/items/item_data/wines/data_ruski_szampan.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://cu6npyyw4hdw6"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://cu6npyyw4hdw6"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_yprbi"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_yprbi"]
 
 [resource]
 script = ExtResource("1_yprbi")
+price = 3.5
 name = &"ruski_szampan"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_sierzant.tres
+++ b/features/items/item_data/wines/data_sierzant.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://b7x6lgg8fa43q"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://b7x6lgg8fa43q"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_o4ix5"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_o4ix5"]
 
 [resource]
 script = ExtResource("1_o4ix5")
+price = 3.5
 name = &"sierzant"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_tas_tas.tres
+++ b/features/items/item_data/wines/data_tas_tas.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://bultpbaukmflj"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://bultpbaukmflj"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_867ok"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_867ok"]
 
 [resource]
 script = ExtResource("1_867ok")
+price = 3.5
 name = &"tas_tas"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_wino.tres
+++ b/features/items/item_data/wines/data_wino.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://b3pbesma7i5hh"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://b3pbesma7i5hh"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_hy1rx"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_hy1rx"]
 
 [resource]
 script = ExtResource("1_hy1rx")
+price = 3.5
 name = &"wino"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/item_data/wines/data_zofia.tres
+++ b/features/items/item_data/wines/data_zofia.tres
@@ -1,10 +1,11 @@
-[gd_resource type="Resource" script_class="ItemData" format=3 uid="uid://cg8m208ctt4sg"]
+[gd_resource type="Resource" script_class="ProductData" format=3 uid="uid://cg8m208ctt4sg"]
 
-[ext_resource type="Script" uid="uid://rfypjk406hn7" path="res://features/items/item_data/item_data.gd" id="1_0cdsx"]
+[ext_resource type="Script" uid="uid://bjdyvmcp7aon" path="res://features/items/item_data/product_data.gd" id="1_0cdsx"]
 
 [resource]
 script = ExtResource("1_0cdsx")
+price = 3.5
 name = &"zofia"
 type = 2
 preview_zoom = -0.4
-metadata/_custom_type_script = "uid://rfypjk406hn7"
+metadata/_custom_type_script = "uid://bjdyvmcp7aon"

--- a/features/items/wine/wino_p_breslau.tscn
+++ b/features/items/wine/wino_p_breslau.tscn
@@ -14,7 +14,7 @@ freeze = true
 script = ExtResource("1_or3wt")
 data = ExtResource("2_2tulp")
 metadata/can_interact = true
-metadata/reticle_tooltip = ""
+metadata/reticle_tooltip = "Breslau"
 
 [node name="wino_p_breslau" parent="." unique_id=1296700530 instance=ExtResource("2_or3wt")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.14, 0)

--- a/features/level/assets/available_items/available_items.gd
+++ b/features/level/assets/available_items/available_items.gd
@@ -1,9 +1,28 @@
 class_name AvailableItems extends Node
 
-@export var item_name_to_instance_map: Dictionary[StringName, Item] = {}
+var item_name_to_instance_map: Dictionary[StringName, Item] = {}
 @export var item_type_to_destination_map: Dictionary[ItemData.Type, Node3D] = {}
 @export var item_name_to_destination_map: Dictionary[StringName, Node3D] = {}
 @export var pickup_at_counter_required: Dictionary[StringName, bool] = {}
+@export var pickup_at_counter_type_required: Dictionary[ItemData.Type, bool] = {}
+
+var item_names: Array[StringName] = []
+var item_names_by_type: Dictionary[ItemData.Type, Array] = {
+	ItemData.Type.SZLUGI: [],
+	ItemData.Type.PIWO: [],
+	ItemData.Type.WINO: [],
+	ItemData.Type.MISC: []
+}
+
+func _ready() -> void:
+	for item: Item in get_tree().get_nodes_in_group(&"items"):
+		if item.data.name not in item_names and item.data is ProductData:
+			item_names.append(item.data.name)
+			item_name_to_instance_map[item.data.name] = item
+
+			if item.data.type == ItemData.Type.APPLIANCE:
+				continue
+			item_names_by_type[item.data.type].append(item.data.name)
 
 func get_item(item_name: StringName) -> Item:
 	if item_name in item_name_to_instance_map:
@@ -13,23 +32,36 @@ func get_item(item_name: StringName) -> Item:
 		return null
 
 func get_all_item_names() -> Array[StringName]:
-	return item_name_to_instance_map.keys()
+	return item_names
 
+# Checks in order: 
+# 1. If product, by name, needs to be picked up at counter 
+# 2. Destination of pickup by product name
+# 3. If product type needs to be picked up at counter
+# 4. Destination of pickup by product type
+# 5. Returns the ite itself as a fallback destination
 func get_item_destination_position(item_name: StringName) -> Node3D:
+	# if product is not available, return error
+	if not item_name in item_name_to_instance_map:
+		push_error("No item with name %s found in AvailableItems." % item_name)
+		return null
+
+	# If pickup of item, by product name, at counter is required, return counter as destination
 	if pickup_at_counter_required.get(item_name, false):
 		return Counter.instance
 
+	# If product, by name, has defined pickup destination, return it
 	if item_name in item_name_to_destination_map:
 		return item_name_to_destination_map[item_name]
 	
-	if item_name in item_name_to_instance_map:
-		var item: Item = item_name_to_instance_map[item_name]
+	var item: Item = item_name_to_instance_map[item_name]
+	# If product type needs to be picked up at counter, return counter as destination
+	if pickup_at_counter_type_required.get(item.data.type, false):
+		return Counter.instance
 
-		if item.data.type in item_type_to_destination_map:
-			return item_type_to_destination_map[item.data.type]
-		else:
-			push_warning("No destination defined for item type %s." % item.data.type)
-			return item
-	else:
-		push_error("No item with name %s found in AvailableItems." % item_name)
-		return null
+	# If product type has defined pickup destination, return it
+	if item.data.type in item_type_to_destination_map:
+		return item_type_to_destination_map[item.data.type]
+	
+	push_warning("No destination defined for item type %s." % item.data.type)
+	return item

--- a/features/level/level.tscn
+++ b/features/level/level.tscn
@@ -47,7 +47,7 @@
 [ext_resource type="PackedScene" uid="uid://bgi3sn72fpicy" path="res://features/items/beer/beer_ovecky_bottle.tscn" id="32_gb2y8"]
 [ext_resource type="PackedScene" uid="uid://k58bns261dml" path="res://features/items/cigarettes/meshes/fajki_03.gltf" id="32_gy3pj"]
 [ext_resource type="PackedScene" uid="uid://c2a2asi2lh4im" path="res://features/items/cigarettes/meshes/fajki_04.gltf" id="33_d4cch"]
-[ext_resource type="PackedScene" path="res://features/items/wine/wino_p_Jabluszko_pomorskie.tscn" id="33_rr5fb"]
+[ext_resource type="PackedScene" path="res://features/items/wine/wino_p_jabluszko_pomorskie.tscn" id="33_rr5fb"]
 [ext_resource type="PackedScene" uid="uid://b73pyd8yanm3n" path="res://features/items/cigarettes/meshes/fajki_05.gltf" id="34_0aatt"]
 [ext_resource type="PackedScene" uid="uid://37ile3adfut7" path="res://features/items/beer/beer_boskie_bottle.tscn" id="34_f2wry"]
 [ext_resource type="PackedScene" uid="uid://bamiv2fbdo4tf" path="res://features/items/wine/wino_p_krolewskie.tscn" id="34_klck8"]
@@ -95,15 +95,17 @@ agent_radius = 0.3
 agent_max_climb = 0.1
 edge_max_error = 1.0
 
-[node name="Level2" type="Node3D" unique_id=1068480335]
+[node name="Level" type="Node3D" unique_id=1068480335]
 script = ExtResource("1_5cegx")
 
-[node name="AvailableItems" type="Node" parent="." unique_id=1624505476]
+[node name="AvailableItems" type="Node" parent="." unique_id=1624505476 node_paths=PackedStringArray("item_type_to_destination_map")]
 unique_name_in_owner = true
 script = ExtResource("2_vk6of")
-pickup_at_counter_required = Dictionary[StringName, bool]({
-&"jabluszko_pomorskie": true,
-&"kiceroy": true
+item_type_to_destination_map = {
+1: NodePath("../Fridge")
+}
+pickup_at_counter_type_required = Dictionary[int, bool]({
+0: true
 })
 
 [node name="WorldEnvironment" type="WorldEnvironment" parent="." unique_id=1955529485]

--- a/features/level/level1.tscn
+++ b/features/level/level1.tscn
@@ -56,7 +56,7 @@
 [ext_resource type="PackedScene" uid="uid://cyuotmgytmcxd" path="res://features/items/wine/wino_m_pippolo.tscn" id="55_7mfxo"]
 [ext_resource type="PackedScene" uid="uid://t0pcv51vktr4" path="res://features/items/wine/wino_m_ruski_szampan.tscn" id="56_xtgde"]
 [ext_resource type="PackedScene" uid="uid://h4nn4lnkqys6" path="res://features/items/wine/wino_p_breslau.tscn" id="57_fgv1h"]
-[ext_resource type="PackedScene" path="res://features/items/wine/wino_p_Jabluszko_pomorskie.tscn" id="58_f8nfe"]
+[ext_resource type="PackedScene" path="res://features/items/wine/wino_p_jabluszko_pomorskie.tscn" id="58_f8nfe"]
 [ext_resource type="PackedScene" uid="uid://bamiv2fbdo4tf" path="res://features/items/wine/wino_p_krolewskie.tscn" id="59_2viwx"]
 [ext_resource type="PackedScene" uid="uid://ccqhyjjalr6hq" path="res://features/items/wine/wino_p_zofia.tscn" id="60_16gfv"]
 [ext_resource type="PackedScene" uid="uid://brlv4vr5lvuuu" path="res://features/items/wine/wino_s_arena.tscn" id="61_1vfrm"]

--- a/features/npc/Basia/basia.tscn
+++ b/features/npc/Basia/basia.tscn
@@ -38,8 +38,10 @@ animation = &"Rig/Walk_Base"
 [sub_resource type="AnimationNodeBlendSpace1D" id="AnimationNodeBlendSpace1D_xgun3"]
 blend_point_0/node = SubResource("AnimationNodeAnimation_qlnrj")
 blend_point_0/pos = 0.0
+blend_point_0/name = &"0"
 blend_point_1/node = SubResource("AnimationNodeAnimation_xcwia")
 blend_point_1/pos = 1.0
+blend_point_1/name = &"1"
 
 [sub_resource type="AnimationNodeBlendTree" id="AnimationNodeBlendTree_vssg2"]
 nodes/output/position = Vector2(540, 140)
@@ -60,6 +62,8 @@ collision_layer = 8
 axis_lock_angular_x = true
 axis_lock_angular_z = true
 script = ExtResource("1_qlnrj")
+number_of_products_wanted = 4
+wanted_product_categories = Array[int]([0, 1, 2])
 metadata/can_interact = true
 metadata/reticle_tooltip = "Basia"
 

--- a/features/npc/shared/npc.gd
+++ b/features/npc/shared/npc.gd
@@ -12,6 +12,8 @@ var wanted_products: Array[StringName]
 var _target_node: Node3D
 var _navigation_interrupted: bool = false
 
+@export var number_of_products_wanted: int = 3
+@export var wanted_product_categories: Array[ItemData.Type] = [ItemData.Type.SZLUGI, ItemData.Type.PIWO, ItemData.Type.WINO, ItemData.Type.MISC]
 
 @onready var nav_agent: NavigationAgent3D = %NavigationAgent3D
 @onready var animation_tree: AnimationTree = %AnimationTree

--- a/features/npc/shared/states/entering_store_state.gd
+++ b/features/npc/shared/states/entering_store_state.gd
@@ -5,8 +5,20 @@ func enter() -> void:
 	print("%s wchodzi do sklepu..." % npc.name)
 	await get_tree().create_timer(5.0).timeout
 	print("%s skonczyla wchodzic do sklepu." % npc.name)
+
 	print("Tu bedzie losowanie produktow, jakie chce %s." % npc.name)
-	npc.wanted_products = Level.instance.available_items.get_all_item_names().slice(0, 2)
+	for i in range(npc.number_of_products_wanted):
+		var item_names_by_type: Dictionary[ItemData.Type, Array] = Level.instance.available_items.item_names_by_type
+
+		var available_categories: Array[ItemData.Type] = npc.wanted_product_categories.filter(func(category: ItemData.Type) -> bool:
+			return item_names_by_type[category].size() > 0
+		)
+
+		var random_category: ItemData.Type = available_categories.pick_random()
+		var random_product: StringName = item_names_by_type[random_category].pick_random()
+		if random_product != null:
+			npc.wanted_products.append(random_product)
+
 	print("%s chce: %s" % [npc.name, ", ".join(npc.wanted_products)])
 	transition.emit(npc.brain.get_next_state(self))
 

--- a/features/npc/shared/states/getting_product_state.gd
+++ b/features/npc/shared/states/getting_product_state.gd
@@ -13,10 +13,17 @@ func enter() -> void:
 	counter_pickup_required_products = []
 	wanted_products = []
 	for product_name in npc.wanted_products:
-		if Level.instance.available_items.pickup_at_counter_required.get(product_name, false):
+		var available_items: AvailableItems = Level.instance.available_items
+		if available_items.pickup_at_counter_required.get(product_name, false):
 			counter_pickup_required_products.append(product_name)
-		else:
-			wanted_products.append(product_name)
+			continue
+
+		var product_type: ItemData.Type = available_items.get_item(product_name).data.type
+		if available_items.pickup_at_counter_type_required.get(product_type, false):
+			counter_pickup_required_products.append(product_name)
+			continue
+
+		wanted_products.append(product_name)
 
 	_go_to_next_product()
 

--- a/features/npc/shared/states/paying_state.gd
+++ b/features/npc/shared/states/paying_state.gd
@@ -24,7 +24,8 @@ func physics_update(_delta: float) -> void:
 
 func _on_animation_finished(anim_name: StringName) -> void:
 	if anim_name == &"Rig/PutDown_Base":
-		CashRegister.instance.generate_random_order()
+		# CashRegister.instance.generate_random_order()
+		CashRegister.instance.generate_order_and_payment()
 
 func _on_transaction_finished() -> void:
 	transition.emit(npc.brain.get_next_state(self))

--- a/features/npc/shared/states/standing_in_queue_state.gd
+++ b/features/npc/shared/states/standing_in_queue_state.gd
@@ -56,3 +56,4 @@ func _look_at_counter() -> void:
 
 func exit() -> void:
 	Game.instance.npc_in_queue_moved.disconnect(_move_in_queue)
+	CashRegister.instance.start_new_order()

--- a/features/npc/shared/states/unloading_products_on_counter_state.gd
+++ b/features/npc/shared/states/unloading_products_on_counter_state.gd
@@ -6,7 +6,7 @@ class_name NPCUnloadingProductsOnCounterState extends NPCState
 
 func enter() -> void:
 	animation_tree.animation_finished.connect(_on_animation_finished)
-	Counter.instance.item_placed.connect(_on_counter_item_placed)
+	Counter.instance.product_placed.connect(_on_counter_product_placed)
 
 	if not npc.inventory.get_items().is_empty():
 		print("%s ma loot w eq. Odkłada produkty na ladę." % npc.name)
@@ -29,20 +29,16 @@ func _on_animation_finished(anim_name: StringName) -> void:
 	if anim_name == &"Rig/PutDown_Base":
 		_unload_inventory_on_counter()
 
-func _on_counter_item_placed(item_data: ItemData) -> void:
+func _on_counter_product_placed(item_data: ProductData) -> void:
 	if npc.wanted_products.has(item_data.name):
 		npc.wanted_products.erase(item_data.name)
 
-	if npc.wanted_products.is_empty():
-		transition.emit(npc.brain.get_next_state(self))
-
 func _unload_inventory_on_counter() -> void:
 	for item: Item in npc.inventory.get_items():
-		var interact_event: InputEventAction = InputEventAction.new()
-		interact_event.action = &"interact"
-		interact_event.pressed = true
-		Counter.instance.interact(interact_event, item)
+		Counter.instance.place_item_from_npc(item)
+
+	transition.emit(npc.brain.get_next_state(self))
 
 func exit() -> void:
 	animation_tree.animation_finished.disconnect(_on_animation_finished)
-	Counter.instance.item_placed.disconnect(_on_counter_item_placed)
+	Counter.instance.product_placed.disconnect(_on_counter_product_placed)

--- a/features/npc/shared/states/waiting_for_product_state.gd
+++ b/features/npc/shared/states/waiting_for_product_state.gd
@@ -5,9 +5,10 @@ class_name NPCWaitingForProductState extends NPCState
 
 
 func enter() -> void:
-	Counter.instance.item_placed.connect(_on_counter_item_placed)
+	Counter.instance.product_placed.connect(_on_counter_product_placed)
 	npc.set_meta(&"can_interact", true)
 	print("%s podchodzi do lady. Tu bedzie okienko dialogowe. Na razie czeka na : %s" % [npc.name, ", ".join(npc.wanted_products)])
+	Counter.instance.npc_at_counter = npc
 
 func input_event(_event: InputEvent) -> void:
 	pass
@@ -20,7 +21,7 @@ func update(_delta: float) -> void:
 func physics_update(_delta: float) -> void:
 	pass
 
-func _on_counter_item_placed(item_data: ItemData) -> void:
+func _on_counter_product_placed(item_data: ProductData) -> void:
 	if npc.wanted_products.has(item_data.name):
 		npc.wanted_products.erase(item_data.name)
 
@@ -28,5 +29,6 @@ func _on_counter_item_placed(item_data: ItemData) -> void:
 		transition.emit(npc.brain.get_next_state(self))
 
 func exit() -> void:
-	Counter.instance.item_placed.disconnect(_on_counter_item_placed)
+	Counter.instance.product_placed.disconnect(_on_counter_product_placed)
+	Counter.instance.npc_at_counter = null
 	npc.set_meta(&"can_interact", false)


### PR DESCRIPTION
Product costs and baseline customer orders:
- added cost to products item data
- added cost counting to CashRegister, whenever an item is placed on the counter
- added order registration adn tracking
- added guards that prevent player to put items not wanted by the customer on the counter